### PR TITLE
Fix install line in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ globus_gridftp_server_posix.o:
 		$(DSI_LDFLAGS) $(DSI_LIBS)
 
 install:
-	cp -f libglobus_gridftp_server_posix_$(FLAVOR).so $(GLOBUS_LOCATION)/ 
-lib
+	cp -f libglobus_gridftp_server_posix_$(FLAVOR).so $(GLOBUS_LOCATION)/lib
 
 clean:
 	rm -f *.so


### PR DESCRIPTION
The `lib` at the end of the install line got moved onto the next line somehow, which was breaking compilation.